### PR TITLE
Fix extend paths in router and store

### DIFF
--- a/generator/templates/simple/src/router.js
+++ b/generator/templates/simple/src/router.js
@@ -1,5 +1,5 @@
 ---
-extend: '@vue/cli-service/generator/template/src/router.js'
+extend: '@vue/cli-service/generator/router/template/src/router.js'
 replace:
   - !!js/regexp /import Vue from 'vue'/
 ---

--- a/generator/templates/simple/src/store.js
+++ b/generator/templates/simple/src/store.js
@@ -1,5 +1,5 @@
 ---
-extend: '@vue/cli-service/generator/template/src/store.js'
+extend: '@vue/cli-service/generator/vuex/template/src/store.js'
 replace:
   - !!js/regexp /import Vue from 'vue'/
 ---


### PR DESCRIPTION
Allows the plugin to work with newer versions of vue-cli past [`2a195f0`](https://github.com/vuejs/vue-cli/commit/2a195f0298fc06318ed8c46beb5bda2c52b4580b) (beta 11).

Edit: I'm not sure if you want to change how the router and store are implemented entirely, as since the linked change, the store and router have been optional in newly-generated projects.