### PR TITLE
Remove semicolon in data options for Sass

### DIFF
--- a/index.js
+++ b/index.js
@@ -573,7 +573,7 @@ const nativeConfig = (api, projectOptions, env, jsOrTs, projectRoot, platform) =
           {
             minimize: false,
             url: false,
-            data: '$PLATFORM: ' + platform + ';'
+            data: '$PLATFORM: ' + platform
           }
         )
       )
@@ -590,7 +590,7 @@ const nativeConfig = (api, projectOptions, env, jsOrTs, projectRoot, platform) =
           {
             minimize: false,
             url: false,
-            data: '$PLATFORM: ' + platform + ';'
+            data: '$PLATFORM: ' + platform
           }
         )
       )


### PR DESCRIPTION
With the current config, it's not possible to use .sass files as the data option contains a semicolon.