### PR TITLE
Fix .gitignore not ignoring webpack.config.js

### DIFF
--- a/generator/index.js
+++ b/generator/index.js
@@ -548,7 +548,7 @@ const gitignoreAdditions = (module.exports.gitignoreAdditions = async (api) => {
   try {
     let gitignoreContent;
     const gitignorePath = api.resolve('.gitignore');
-    const gitignoreAdditions = newline + '# NativeScript application' + newline + 'hooks' + newline + 'platforms' + newline + './webpack.config.js';
+    const gitignoreAdditions = newline + '# NativeScript application' + newline + 'hooks' + newline + 'platforms' + newline + 'webpack.config.js';
 
     if (fs.existsSync(gitignorePath)) {
       gitignoreContent = fs.readFileSync(gitignorePath, {


### PR DESCRIPTION
The path, when used with `./webpack.config.js` does not seem to apply to ignore the file - as a result it gets committed.