### PR TITLE
Fix "You need to provide a target platform!" error on clean project

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,10 @@ module.exports = (api, projectOptions) => {
   // console.log('platform - ', platform);
 
   if (!platform) {
-    throw new Error('You need to provide a target platform!');
+    // TNS (iOS/Android) always sets platform, so assume platform = 'web' & Vue-CLI glitch of loosing .env options in the UI
+    platform = 'web';
+    //    --> TO BE DELETED SOON
+    // throw new Error('You need to provide a target platform!');
   }
 
   const projectRoot = api.service.context;


### PR DESCRIPTION
Fix "You need to provide a target platform!" error on clean project `npm run serve:web` launched from UI 
+ `npm run serve:web` (UI)
+ `npm run lint` (both UI & CLI)
+ `npm run inspect` (both UI & CLI)

(#16 )