### PR TITLE
Allow use of <template> within template

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ const resolveExtensionsOptions = {
 };
 
 const getBlockRegex = (tag, mode) => {
-  return `^((<${tag})(.+\\b${mode}\\b))([\\s\\S]*?>)[\\s\\S]*?(<\\/${tag}>)`;
+  return `^((<${tag})(.+\\b${mode}\\b))([\\s\\S]*?>)[\\s\\S]*(<\\/${tag}>)(?=[\\s\\S]*?<${tag}.+\\b${mode === 'web' ? 'native' : 'web'}\\b[\\s\\S]*?>)|^((<${tag})(.+\\b${mode}\\b))([\\s\\S]*?>)[\\s\\S]*?(<\\/${tag}>)`;
 };
 
 module.exports = (api, projectOptions) => {

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ const resolveExtensionsOptions = {
 };
 
 const getBlockRegex = (tag, mode) => {
-  return `^((<${tag})(.+\\b${mode}\\b))([\\s\\S]*?>)[\\s\\S]*(<\\/${tag}>)(?=[\\s\\S]*?<${tag}.+\\b${mode === 'web' ? 'native' : 'web'}\\b[\\s\\S]*?>)|^((<${tag})(.+\\b${mode}\\b))([\\s\\S]*?>)[\\s\\S]*?(<\\/${tag}>)`;
+  return `^((<${tag})(.+\\b${mode}\\b))([\\s\\S]*?>)((?=[\\s\\S]*?<${tag}.+\\b${mode === 'web' ? 'native' : 'web'}\\b[\\s\\S]*?>)([\\s\\S]+(?=[\\s\\S]*?<${tag}.+\\b${mode === 'web' ? 'native' : 'web'}\\b[\\s\\S]*?>))|([\\s\\S]+<\\/${tag}>))`;
 };
 
 module.exports = (api, projectOptions) => {


### PR DESCRIPTION
Currently, if I use a **template** tag within my main **<template native|web>**, the regex pattern will stop at the first closing **template** and the compiler will throw an error. I have found a way around it by adding a positive lookahead for a starting **<template native|web>**. If none is found, it falls back to the current pattern. I don't know if that's the most elegant way to do it but at least it works :)