### PR TITLE
Sass Loader unknow property 'minimize'

### DIFF
--- a/index.js
+++ b/index.js
@@ -669,7 +669,7 @@ const nativeConfig = (api, projectOptions, env, projectRoot, platform) => {
             .uses.get('sass-loader')
             .get('options'),
           {
-            minimize: false,
+            // minimize: false,
             // url: false,
             prependData: '$PLATFORM: ' + platform
           }


### PR DESCRIPTION
## What's happening

After upgrading my Nativescript project to 6.3.1 I got the error bellow when using Sass.

Error message:

```
ERROR in ./components/Main.vue?vue&type=style&index=0&lang=sass& (../node_modules/nativescript-dev-webpack/style-hot-loader.js!../node_modules/nativescript-dev-webpack/apply-css-loader.js!../node_modules/css-loader/dist/cjs.js??ref--7-oneOf-0-2!../node_modules/vue-loader/lib/loaders/stylePostLoader.js!../node_modules/postcss-loader/src??ref--7-oneOf-0-3!../node_modules/sass-loader/dist/cjs.js??ref--7-oneOf-0-4!../node_modules/vue-loader/lib??vue-loader-options!../node_modules/string-replace-loader??ref--12-1!./components/Main.vue?vue&type=style&index=0&lang=sass&)
Module build failed (from ../node_modules/sass-loader/dist/cjs.js):
ValidationError: Invalid options object. Sass Loader has been initialised using an options object that does not match the API schema.
 - options has an unknown property 'minimize'. These properties are valid:
   object { implementation?, sassOptions?, prependData?, sourceMap?, webpackImporter? }
```

## Solution

Commenting out the invalid option did the trick.